### PR TITLE
Bump ephemeral version and add required configuration arguments

### DIFF
--- a/helmfile.d/0300.ephemeral.yaml
+++ b/helmfile.d/0300.ephemeral.yaml
@@ -19,13 +19,13 @@ repositories:
 releases:
 - name: {{ requiredEnv "RELEASE_NAME" }}-ephemeral
   chart: carbynestack-oci/ephemeral
-  version: "0.1-SNAPSHOT-2280825554-16-c43d17c"
+  version: "0.1-SNAPSHOT-2804677120-20-efc7f8d"
   values:
     - discovery:
         image:
           registry: {{ env "DISCOVERY_IMAGE_REGISTRY" | default "ghcr.io" }}
           repository: {{ env "DISCOVERY_IMAGE_REPOSITORY" | default "carbynestack/ephemeral/discovery" }}
-          tag: {{ env "DISCOVERY_IMAGE_TAG" | default "0.1-SNAPSHOT-2280825554-16-c43d17c" }}
+          tag: {{ env "DISCOVERY_IMAGE_TAG" | default "0.1-SNAPSHOT-2804677120-20-efc7f8d" }}
           {{ if env "IMAGE_PULL_SECRET" }}
           pullSecrets:
             - {{ env "IMAGE_PULL_SECRET" }}
@@ -39,7 +39,7 @@ releases:
         image:
           registry: {{ env "EPHEMERAL_IMAGE_REGISTRY" | default "ghcr.io" }}
           repository: {{ env "EPHEMERAL_IMAGE_REPOSITORY" | default "carbynestack/ephemeral/ephemeral" }}
-          tag: {{ env "EPHEMERAL_IMAGE_TAG" | default "0.1-SNAPSHOT-2280825554-16-c43d17c" }}
+          tag: {{ env "EPHEMERAL_IMAGE_TAG" | default "0.1-SNAPSHOT-2804677120-20-efc7f8d" }}
           {{ if env "IMAGE_PULL_SECRET" }}
           pullSecrets:
             - {{ env "IMAGE_PULL_SECRET" }}
@@ -53,17 +53,25 @@ releases:
           host: {{ requiredEnv "RELEASE_NAME" }}-amphora:10000
           scheme: "http"
           path: "/"
+        castor:
+          host: {{ requiredEnv "RELEASE_NAME" }}-castor:10100
+          scheme: "http"
+          path: "/"
         frontendUrl: {{ requiredEnv "FRONTEND_URL" }}
         discoveryAddress: {{ requiredEnv "RELEASE_NAME" }}-ephemeral-discovery
         playerId: {{ if eq (env "IS_MASTER") "true" }}0{{ else }}1{{ end }}
         spdz:
           prime: {{ env "SPDZ_PRIME" | default "198766463529478683931867765928436695041" | quote }}
           rInv: {{ env "SPDZ_R_INV" | default "133854242216446749056083838363708373830" | quote }}
+          gfpMacKey: {{ if eq (env "IS_MASTER") "true" }} {{ env "SPDZ_GFP_MAC_KEY" | default "-88222337191559387830816715872691188861" | quote }} {{ else }} {{ env "SPDZ_GFP_MAC_KEY" | default "1113507028231509545156335486838233835" | quote }} {{ end }}
+          gf2nMacKey: {{ if eq (env "IS_MASTER") "true" }} {{ env "SPDZ_GF2N_MAC_KEY" | default "0xb660b323e6" | quote }} {{ else }} {{ env "SPDZ_GF2N_MAC_KEY" | default "0x4ec9a0343c" | quote }} {{ end }}
+          gf2nBitLength: {{ env "SPDZ_GF2N_BIT_LENGTH" | default 40 }}
+          gf2nStorageSize: {{ env "SPDZ_GF2N_STORAGE_SIZE" | default 8 }}
     - networkController:
         image:
           registry: {{ env "NETWORK_CONTROLLER_IMAGE_REGISTRY" | default "ghcr.io" }}
           repository: {{ env "NETWORK_CONTROLLER_IMAGE_REPOSITORY" | default "carbynestack/ephemeral/network-controller" }}
-          tag: {{ env "NETWORK_CONTROLLER_IMAGE_TAG" | default "0.1-SNAPSHOT-2280825554-16-c43d17c" }}
+          tag: {{ env "NETWORK_CONTROLLER_IMAGE_TAG" | default "0.1-SNAPSHOT-2804677120-20-efc7f8d" }}
           {{ if env "IMAGE_PULL_SECRET" }}
           pullSecrets:
             - {{ env "IMAGE_PULL_SECRET" }}


### PR DESCRIPTION
blocked until carbynestack/ephemeral#28 has been merged and version ephemeral was updated